### PR TITLE
Dampen expectations on future WebAssembly features

### DIFF
--- a/src/basics.md
+++ b/src/basics.md
@@ -72,9 +72,7 @@ WebAssembly modules execute in a sandbox, providing **strong security guarantees
 
 Currently, values WebAssembly can exchange out of the box are **limited to basic numeric values**, and one can think of objects as a clever composition of basic values stored in linear memory. As such, whole **objects cannot yet flow in and out of WebAssembly** natively, making it necessary to translate between their representations in WebAssembly memory and JavaScript objects. This is typically the first real bummer one is going to run into.
 
-For now, there is [the loader](./loader.md) that provides the utility necessary to exchange strings and arrays for example, but it is somewhat edgy on its own due to its garbage collection primitives. It's a great starting point however for learning more about how the higher level structures _actually_ work.
-
-In the near to distant future, the [reference types](https://github.com/WebAssembly/reference-types) 🦄, [interface types](https://github.com/WebAssembly/interface-types) 🦄 and ultimately [GC](https://github.com/WebAssembly/gc) 🦄 proposals will make much of this a lot easier.
+For now, there is [the loader](./loader.md) that provides the utility necessary to exchange strings and arrays for example, but it is somewhat edgy on its own due to its garbage collection primitives. It's a great starting point however, and we are looking into improving the experience.
 
 ## Quirks
 

--- a/src/introduction.md
+++ b/src/introduction.md
@@ -47,6 +47,6 @@ view[2] = view[0] + view[1]
 
 In turn it also comes with a bunch of features JavaScript doesn't have, mostly out of necessity, like the ability to declare [operator overloads](./peculiarities.md#operator-overloads) that arrays for example use as an implementation helper. It's not quite a subset, not quite a superset, but rather a variant.
 
-As of today, the compiler still has its [limitations](./basics.md#current-limitations) and we are waiting for WebAssembly features that are currently undergoing specification \(marked as 🦄 throughout the documentation, especially [Reference Types](https://github.com/WebAssembly/reference-types) 🦄, [Interface Types](https://github.com/WebAssembly/interface-types) 🦄 and [Wasm GC](https://github.com/WebAssembly/gc) 🦄\) to unleash its full potential. But it is open source, built upon an [open specification](https://webassembly.github.io/spec/) and everyone can contribute, so we are getting there.
+As of today, the compiler still has its [limitations](./basics.md#current-limitations) and we are patiently waiting for WebAssembly features that are currently undergoing specification (marked as 🦄 throughout the documentation) to see where these can help AssemblyScript as well.
 
 Sounds appealing to you? Read on!

--- a/src/introduction.md
+++ b/src/introduction.md
@@ -47,6 +47,6 @@ view[2] = view[0] + view[1]
 
 In turn it also comes with a bunch of features JavaScript doesn't have, mostly out of necessity, like the ability to declare [operator overloads](./peculiarities.md#operator-overloads) that arrays for example use as an implementation helper. It's not quite a subset, not quite a superset, but rather a variant.
 
-As of today, the compiler still has its [limitations](./basics.md#current-limitations) and we are patiently waiting for WebAssembly features that are currently undergoing specification (marked as 🦄 throughout the documentation) to see where these can help AssemblyScript as well.
+As of today, the compiler still has its [limitations](./basics.md#current-limitations) and we are patiently waiting for and prototyping future WebAssembly features (marked as 🦄 throughout the documentation) to see where these can help.
 
 Sounds appealing to you? Read on!

--- a/src/runtime.md
+++ b/src/runtime.md
@@ -115,10 +115,6 @@ One common point of confusion here is that the rules above **operate on types, n
 
 By default, the full and half runtime will automatically try to collect cyclic garbage when memory must be grown. This behavior can be disabled by setting `gc.auto = false` in performance critical code. Likewise, if there is a good opportunity to collect cyclic garbage at a given point in time, like if the application is idle, `gc.collect()` can be called to force a full garbage collection cycle. Protip: If no cyclic structures are used, no garbage must be collected.
 
-## Future options
-
-The reason for implementing our own runtime is that the necessary WebAssembly features to replace it are still in the works and none of them so far address interoperability with the Open Web Platform in a meaningful way. So we decided to roll our own for the time being.
-
 ## Implementation
 
 The memory manager used by AssemblyScript is a variant of TLSF \([Two-Level Segregate Fit memory allocator](http://www.gii.upv.es/tlsf/)\) and it is accompanied by PureRC \(a variant of [A Pure Reference Counting Garbage Collector](https://researcher.watson.ibm.com/researcher/files/us-bacon/Bacon03Pure.pdf)\) with [slight modifications of assumptions](https://github.com/dcodeIO/purerc) to avoid unnecessary work. Essentially, TLSF is responsible for partitioning [dynamic memory](./memory.md#dynamic-memory) into chunks that can be used by the various objects, while PureRC keeps track of their lifetimes.

--- a/src/runtime.md
+++ b/src/runtime.md
@@ -117,7 +117,7 @@ By default, the full and half runtime will automatically try to collect cyclic g
 
 ## Future options
 
-The reason for implementing our own runtime is that [WebAssembly GC](https://github.com/WebAssembly/gc) is still in the works without any ETA on it, unfortunately. So we decided to roll our own for the time being, but as soon as WebAssembly GC lands, it is likely that we are going to reconsider alternatives.
+The reason for implementing our own runtime is that the necessary WebAssembly features to replace it are still in the works and none of them so far address interoperability with the Open Web Platform in a meaningful way. So we decided to roll our own for the time being.
 
 ## Implementation
 


### PR DESCRIPTION
Removes several references to WebAssembly features from the documentation in order to dampen expectations. As it turned out, Wasm GC for example will most likely not provide any meaningful interoperability with the Open Web Platform anytime soon, so we shouldn't mention that it may anymore until we know for sure. I also changed wording like "unleash its full potential" or "make much of this a lot easier" to more neutral terms, because my rough ETA for any of this just leaped several years further into the future.

Please let me know if the changes read too grumpy or something. Having a hard time to make the best of it right now.