### PR TITLE
Be more precise when using 'T' in non-generic contexts

### DIFF
--- a/src/stdlib/math.md
+++ b/src/stdlib/math.md
@@ -30,7 +30,7 @@ Where small module size is more important than performance, one can opt to overr
 
 ## Static members
 
-The type `T` below substitutes either `f32` or `f64` depending on the implementation used.
+The type `T` below substitutes either `f32` or `f64` depending on the implementation used. Note that `Math` is not actually generic, but concrete implementations like `Math` and `Mathf` have an identical interface that only differs in the implementation's floating-point precision denoted by `T`.
 
 ### Constants
 

--- a/src/stdlib/typedarray.md
+++ b/src/stdlib/typedarray.md
@@ -6,7 +6,7 @@ description: An Array-like view on a raw binary buffer.
 
 An Array-like view on a raw binary buffer.
 
-The TypedArray API works very much like JavaScript's \([MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray)\). The name `TypedArray` below represents one of the variants of element type `T` and is not an actual class.
+The TypedArray API works very much like JavaScript's \([MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray)\). The name `TypedArray` below represents one of the variants of element type `T` and is not an actual class. Note that typed arrays are not actually generic, but concrete implementations like `Uint8Array` and `Float64Array` have an identical interface that only differs in the implementation's element type denoted as `T`.
 
 ## Variants
 


### PR DESCRIPTION
See https://github.com/AssemblyScript/assemblyscript/issues/1709

cc @ColinEberhardt 