### PR TITLE
Add as-bigint library to built-with-assemblyscript.md

### DIFF
--- a/src/built-with-assemblyscript.md
+++ b/src/built-with-assemblyscript.md
@@ -95,6 +95,8 @@ A place for all things AssemblyScript. Feel free to add your projects and applic
   BSON encoder / decoder.
 * [assemblyscript-json](https://github.com/nearprotocol/assemblyscript-json)<br />
   JSON encoder / decoder.
+* [as-bigint](https://github.com/Web3-API/as-bigint)<br />
+  A BigInt class for math with arbitrarily large integers.
 * [as-bignum](https://github.com/MaxGraey/as-bignum) \(formerly bignum.wasm\)<br />
   Fixed length big numbers like `u128`, `i256`, `fp128` and etc for AssemblyScript.
 * [ASTL](https://github.com/samchon/astl)<br />


### PR DESCRIPTION
Hi everyone,

The Web3API development team has created a BigInt class for math with arbitrarily large integers. We would like to share it on the assemblyscript website to hopefully attract additional users and contributors.

Checkout out the repo: https://github.com/Web3-API/as-bigint

Please let me know what you think!