### PR TITLE
Restructure documentation for v0.19

### DIFF
--- a/src/.vuepress/nav.js
+++ b/src/.vuepress/nav.js
@@ -62,8 +62,16 @@ module.exports = [
         text: 'Extended',
         items: [
           {
+            text: 'Builtins',
+            link: '/stdlib/builtins'
+          },
+          {
             text: 'StaticArray',
             link: '/stdlib/staticarray'
+          },
+          {
+            text: 'heap',
+            link: '/stdlib/heap'
           },
           {
             text: 'process',

--- a/src/.vuepress/redirects
+++ b/src/.vuepress/redirects
@@ -1,4 +1,4 @@
-/basics/environment /environment
+/basics/environment /stdlib/builtins
 /basics/exports-and-imports /exports-and-imports
 /basics/loader /loader
 /basics/types /types
@@ -26,3 +26,4 @@
 /standard-library/typedarray /stdlib/typedarray
 /extended-library/staticarray /stdlib/staticarray
 /faq /frequently-asked-questions
+/environment /stdlib/builtins

--- a/src/.vuepress/sidebar.js
+++ b/src/.vuepress/sidebar.js
@@ -12,21 +12,20 @@ function getDefaultSidebar() {
       collapsable: false,
       children: [
         '/introduction',
-        '/quick-start',
-        '/basics',
-        '/status',
-        '/frequently-asked-questions'
+        '/quick-start'
       ]
     },
     {
       title: 'Documentation',
       collapsable: false,
       children: [
+        '/basics',
+        '/status',
         '/compiler',
         '/types',
-        '/environment',
         '/exports-and-imports',
-        '/loader'
+        '/loader',
+        '/frequently-asked-questions'
       ]
     },
     {
@@ -39,8 +38,8 @@ function getDefaultSidebar() {
         '/portability',
         '/debugging',
         '/interoperability',
-        '/development',
-        '/transforms'
+        '/transforms',
+        '/development'
       ]
     }
   ]
@@ -71,7 +70,9 @@ function getStdlibSidebar() {
       title: 'Extended Library',
       collapsable: false,
       children: [
+        '/stdlib/builtins',
         '/stdlib/staticarray',
+        '/stdlib/heap',
         '/stdlib/process',
         '/stdlib/console',
         '/stdlib/crypto'

--- a/src/.vuepress/styles/index.styl
+++ b/src/.vuepress/styles/index.styl
@@ -85,3 +85,18 @@ div[class~="language-c"]:before {
 }
 
 img.engine { position: relative; top: 3px; }
+
+// API docs: <details><summary> spoiler
+
+details summary {
+  cursor: pointer;
+}
+details summary::marker {
+  color: $arrowBgColor;
+}
+details summary:hover {
+  color: $accentColor;
+}
+details table td {
+  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
+}

--- a/src/basics.md
+++ b/src/basics.md
@@ -2,7 +2,7 @@
 description: There is something appealing to it, isn't it?
 ---
 
-# Basics
+# Basic concepts
 
 WebAssembly is fundamentally different from JavaScript, ultimately enabling entirely new use cases not only on the web. Consequently, AssemblyScript is much more similar to a static compiler than it is to a JavaScript VM. One can think of it as a mix of TypeScript's high level syntax and C's low-level capabilities. This page is dedicated to getting you up to speed in no time.
 

--- a/src/compiler.md
+++ b/src/compiler.md
@@ -2,9 +2,9 @@
 description: How to use the compiler from the command line or as an API.
 ---
 
-# Compiler
+# Using the compiler
 
-Similar to TypeScript's `tsc` compiling to JavaScript, AssemblyScript's `asc` compiles to WebAssembly.
+Similar to TypeScript's `tsc` transpiling to JavaScript, AssemblyScript's `asc` compiles to WebAssembly.
 
 ## Command line options
 

--- a/src/loader.md
+++ b/src/loader.md
@@ -3,7 +3,7 @@ description: How to make working with an AssemblyScript module more convenient.
 sidebarDepth: 2
 ---
 
-# Loader
+# Using the loader
 
 AssemblyScript provides a tiny [module loader](https://github.com/AssemblyScript/assemblyscript/tree/master/lib/loader) that makes working with AssemblyScript modules as convenient as it gets without sacrificing efficiency. It about mirrors the relevant parts of the WebAssembly API while also providing utility to allocate and read strings, arrays and classes.
 

--- a/src/status.md
+++ b/src/status.md
@@ -3,7 +3,7 @@ description: Are we there yet?
 sidebarDepth: 2
 ---
 
-# Status
+# Implementation status
 
 Not all language features are equally viable to implement on top of WebAssembly's current capabilities, and while AssemblyScript is already useful today, there is also still a lot to do. Keep in mind that WebAssembly is an evolving technology, and so is AssemblyScript.
 
@@ -21,15 +21,15 @@ Some crucial language features rely on [future WebAssembly functionality](https:
 |--------------------------------|-------------------------------------|-------------------------|------------------------------------
 | ✔️ **Finished proposal**
 | Import/export mutable globals  | <Ch/> <Fi/> <Sa/> <No/> <Wt/> <Ws/> | ✔️                      | Global variable interop
-| BigInt integration<sup>1</sup> | <Ch/> <Fi/>             <Wt/> <Ws/> | ✔️                      | 64-bit integer interop
+| BigInt integration<sup>1</sup> | <Ch/> <Fi/> <Sa/> <No/> <Wt/> <Ws/> | ✔️                      | 64-bit integer interop
+| Sign-extension                 | <Ch/> <Fi/> <Sa/> <No/> <Wt/> <Ws/> | ✔️                      | Efficient small integer casts
 | Non-trapping F2I               | <Ch/> <Fi/>       <No/> <Wt/> <Ws/> | 🏁 `nontrapping-f2i`    | Checked and unchecked casts
-| Sign-extension                 | <Ch/> <Fi/>       <No/> <Wt/> <Ws/> | 🏁 `sign-extension`     | Efficient small integer casts
-| Reference Types                |       <Fi/>             <Wt/> <Ws/> | 🏁 `reference-types`    | Prerequisite for garbage collection
-| Bulk memory                    | <Ch/> <Fi/>             <Wt/> <Ws/> | 🏁 `bulk-memory`        | Replace `memcpy`, `memset`
-| Multi-value                    | <Ch/> <Fi/> <Sa/>       <Wt/> <Ws/> |                         | Tuple return values
+| Bulk memory                    | <Ch/> <Fi/>       <No/> <Wt/> <Ws/> | 🏁 `bulk-memory`        | Replace `memcpy`, `memset`
+| Reference Types                |       <Fi/>             <Wt/>       | 🏁 `reference-types`    | Prerequisite for garbage collection
+| Multi-value                    | <Ch/> <Fi/> <Sa/> <No/> <Wt/> <Ws/> |                         | Tuple return values
 ||
 | 🏁 **Standardize the feature**
-| Fixed-width SIMD               |                                     | 🔨 `simd`               | Expose as built-ins; Auto-vectorize?
+| Fixed-width SIMD               | <Ch/>                               | 🏁 `simd`               | Expose as built-ins; Auto-vectorize?
 ||
 | 🔨 **Implementation phase**
 | Tail call                      |                                     |                         |
@@ -112,7 +112,7 @@ Some [standard library APIs](./stdlib/globals.md) function a little different th
 
 ### Generics
 
-AssemblyScript compiles generics to one concrete method or function per set of unique contextual type arguments, also known as [monomorphisation](https://en.wiktionary.org/wiki/monomorphisation). Implications are that a module only includes and exports concrete functions for sets of type arguments actually used and that concrete functions can be shortcutted with [static type checks](./environment.md#static-type-checks) at compile time, which turned out to be quite useful.
+AssemblyScript compiles generics to one concrete method or function per set of unique contextual type arguments, also known as [monomorphisation](https://en.wiktionary.org/wiki/monomorphisation). Implications are that a module only includes and exports concrete functions for sets of type arguments actually used and that concrete functions can be shortcutted with [static type checks](./stdlib/builtins.md#static-type-checks) at compile time, which turned out to be quite useful.
 
 * The compiler does not currently enforce `extends Y` clauses on type parameters. Likely to be enforced in the future.
 * WebAssembly GC 🦄 may introduce more sophisticated mechanisms like reified generics, potentially post-MVP.
@@ -134,7 +134,7 @@ See also: [Will interop between AssemblyScript and JavaScript become better?](./
 
 ### Union types
 
-WebAssembly cannot efficiently represent locals or globals of dynamic types, so union types are not supported in AssemblyScript. One can however take advantage of the fact that AssemblyScript is a static compiler, with monomorphized generics and [static type checks](./environment.md#static-type-checks), to achieve a similar effect:
+WebAssembly cannot efficiently represent locals or globals of dynamic types, so union types are not supported in AssemblyScript. One can however take advantage of the fact that AssemblyScript is a static compiler, with monomorphized generics and [static type checks](./stdlib/builtins.md#static-type-checks), to achieve a similar effect:
 
 ```ts
 function addOrConcat<T>(a: T, b: T): T {
@@ -311,7 +311,7 @@ Debugging of AssemblyScript modules is not as convenient as it should be, but [p
 
 ### Testing
 
-The standard library provides the [`assert`](./environment.md#utility) built-in, which does not decide on a particular flavor of testing, yet is often sufficient to write basic tests.
+The standard library provides the [`assert`](./stdlib/builtins.md#utility) built-in, which does not decide on a particular flavor of testing, yet is often sufficient to write basic tests.
 
 Solutions being developed by the community:
 

--- a/src/stdlib/globals.md
+++ b/src/stdlib/globals.md
@@ -4,7 +4,7 @@ description: JavaScript-like elements in the global scope.
 
 # Globals
 
-In addition to the [general environment with its WebAssembly-focused built-ins](../environment.md), the following global constants and functions are present alongside the standard library's classes.
+In addition to [low-level WebAssembly and compiler built-ins](./builtins.md), the following global constants and functions are present alongside the standard library's classes.
 
 ## Constants
 

--- a/src/stdlib/heap.md
+++ b/src/stdlib/heap.md
@@ -1,0 +1,29 @@
+---
+description: Direct access to the memory manager.
+---
+
+# heap
+
+An unsafe interface to use the dynamic memory manager directly, resembling `malloc`, `realloc` and `free`. Manual memory management can be used in parallel to garbage collection, which can be quite handy, but manually managed blocks cannot be mixed with garbage collected objects (i.e. trying to `heap.free` a GC object or casting a block to a managed object respectively would break since one has a GC header and the other does not).
+
+## Static members
+
+* ```ts
+  function heap.alloc(size: usize): usize
+  ```
+  Allocates a chunk of memory of at least the specified size.
+
+* ```ts
+  function heap.realloc(ptr: usize, size: usize): usize
+  ```
+  Reallocates a chunk of memory to have at least the specified size.
+
+* ```ts
+  function heap.free(ptr: usize): void
+  ```
+  Frees a chunk of memory.
+
+* ```ts
+  function heap.reset(): void
+  ```
+  Dangerously resets the entire heap. Specific to the "stub" runtime.

--- a/src/stdlib/math.md
+++ b/src/stdlib/math.md
@@ -262,4 +262,4 @@ The type `T` below substitutes either `f32` or `f64` depending on the implementa
 
 ## Considerations
 
-The Math implementations are meant as a drop-in replacement for JavaScript's Math so sometimes mimic special JavaScript semantics, like `Math.round` always rounding towards `+Infinity`. Also, functions like `Math.fround` or `Math.imul` do not return an `f32` respectively an `i32` as some might expect for the same reason. Hence, depending on the use case, using [WebAssembly's math instructions](../environment.md#math) directly can be a worthwhile alternative where portability is not a concern.
+The Math implementations are meant as a drop-in replacement for JavaScript's Math so sometimes mimic special JavaScript semantics, like `Math.round` always rounding towards `+Infinity`. Also, functions like `Math.fround` or `Math.imul` do not return an `f32` respectively an `i32` as some might expect for the same reason. Hence, depending on the use case, using [WebAssembly's math instructions](./builtins.md#math) directly can be a worthwhile alternative where portability is not a concern.

--- a/src/types.md
+++ b/src/types.md
@@ -2,7 +2,7 @@
 description: When one number just doesn't cut it.
 ---
 
-# Types
+# WebAssembly types
 
 Instead of using the `number` type for all sorts of numeric values, AssemblyScript inherits WebAssembly's more specific integer and floating point types:
 


### PR DESCRIPTION
* Updates documentation for SIMD, including which `T`s are valid and their now-final corresponding Wasm instructions.
* Removed the **Environment** page and moved its contents to **Extended library** / Builtins and heap.
* Reworded the **Introduction**, emphasizing low-level and high-level perspectives.
* Moves **Basics**, **Status** and **FAQ** from **Getting started** to **Documentation**
* Updates the **Status** page.