### PR TITLE
fix typo in docs: WebAssembly types / Type rules / Bit shifts

### DIFF
--- a/src/types.md
+++ b/src/types.md
@@ -88,10 +88,10 @@ Note that only the `log2(sizeof<T>())` least signficant bits of the shift affect
 
 | Type      | Significant bits | Example
 | :-------- | :--------------: | :------------------------
-| i8 / u8   | 3                | `x & y` ≡ `x & (y & 7)`
-| i16 / u16 | 4                | `x & y` ≡ `x & (y & 15)`
-| i32 / u32 | 5                | `x & y` ≡ `x & (y & 31)`
-| i64 / u64 | 6                | `x & y` ≡ `x & (y & 63)`
+| i8 / u8   | 3                | `x << y` ≡ `x << (y & 7)`
+| i16 / u16 | 4                | `x << y` ≡ `x << (y & 15)`
+| i32 / u32 | 5                | `x << y` ≡ `x << (y & 31)`
+| i64 / u64 | 6                | `x << y` ≡ `x << (y & 63)`
 
 If the left type is a float, an error is emitted.
 


### PR DESCRIPTION
This PR fixes a typo in [WebAssembly types / Type Rules / Bit shift](https://www.assemblyscript.org/types.html#bit-shifts) section of the documentation.