### PR TITLE
Remove "@latest" form pathes

### DIFF
--- a/src/.vuepress/public/editor.html
+++ b/src/.vuepress/public/editor.html
@@ -316,8 +316,8 @@
   <script type="importmap">
     {
       "imports": {
-        "assemblyscript": "https://cdn.jsdelivr.net/npm/assemblyscript@latest/dist/assemblyscript.js",
-        "assemblyscript/asc": "https://cdn.jsdelivr.net/npm/assemblyscript@latest/dist/asc.js",
+        "assemblyscript": "https://cdn.jsdelivr.net/npm/assemblyscript/dist/assemblyscript.js",
+        "assemblyscript/asc": "https://cdn.jsdelivr.net/npm/assemblyscript/dist/asc.js",
         "binaryen": "https://cdn.jsdelivr.net/npm/binaryen@109.0.0-nightly.20220813/index.js",
         "long": "https://cdn.jsdelivr.net/npm/long@5.2.0/index.min.js"
       },


### PR DESCRIPTION
jsdelivr's cache behave really strange again. Probably, we should do this every time for cache invalidation