### PR TITLE
Update outdated links in examples

### DIFF
--- a/src/examples/interference.md
+++ b/src/examples/interference.md
@@ -121,7 +121,7 @@ As soon as this condition is no longer met, one would instead either reserve som
 
 ## Running locally
 
-Set up a new AssemblyScript project as described in [Quick start](../quick-start.md) and copy `module.ts` to `assembly/index.ts` and `index.html` to the project's top-level directory. Edit the build commands in `package.json` to include
+Set up a new AssemblyScript project as described in [Getting started](../getting-started.md) and copy `module.ts` to `assembly/index.ts` and `index.html` to the project's top-level directory. Edit the build commands in `package.json` to include
 
 ```
 --runtime stub

--- a/src/examples/mandelbrot.md
+++ b/src/examples/mandelbrot.md
@@ -155,7 +155,7 @@ As soon as these conditions are no longer met, one would instead either reserve 
 
 ## Running locally
 
-Set up a new AssemblyScript project as described in [Quick start](../quick-start.md) and copy `module.ts` to `assembly/index.ts` and `index.html` to the project's top-level directory. Edit the build commands in `package.json` to include
+Set up a new AssemblyScript project as described in [Getting started](../getting-started.md) and copy `module.ts` to `assembly/index.ts` and `index.html` to the project's top-level directory. Edit the build commands in `package.json` to include
 
 ```
 --runtime stub --use Math=JSMath --importMemory


### PR DESCRIPTION
Links to quick-start.md were broken (unless they were opened in another tab). Now, it links to getting-started.md as it should. Note that the actual content is still outdated.

Fixes #194.