### PR TITLE
Added a new section `Demoscene` to `built-with-assemblyscript.md`

### DIFF
--- a/src/built-with-assemblyscript.md
+++ b/src/built-with-assemblyscript.md
@@ -51,6 +51,11 @@ A place for all things AssemblyScript. Feel free to add your projects and applic
 * [visitor-as](https://github.com/willemneal/visitor-as)<br />
   Tools for creating compiler transformers.
 
+## Demoscene
+
+* [Hoofdkantoor WASM Demo](https://wasm-demo.codument.com/demo.html)<br />
+  A demo built with AssemblyScript (also TS and Web Audio API). It's an homage to the old school Demoscene of the early 90s.
+
 ## Editors
 
 * [Fastly Terrarium](https://wasm.fastlylabs.com/)<br />

--- a/src/built-with-assemblyscript.md
+++ b/src/built-with-assemblyscript.md
@@ -53,7 +53,7 @@ A place for all things AssemblyScript. Feel free to add your projects and applic
 
 ## Demoscene
 
-* [Hoofdkantoor WASM Demo](https://wasm-demo.codument.com/demo.html)<br />
+* [Hoofdkantoor WASM Demo](https://wasm-demo.codument.com)<br />
   A demo built with AssemblyScript (also TS and Web Audio API). It's an homage to the old school Demoscene of the early 90s.
 
 ## Editors


### PR DESCRIPTION
As agreed with @MaxGraey, here's a PR with a new section `Demoscene` added to `built-with-assemblyscript.md` in order to accommodate an AssemblyScript/WASM demo.

(I don't seem to be able to add labels or add people as reviewers in this PR :thinking:, so my excuses for not labeling the PR, etc.)