### PR TITLE
Bump Node.js version to v20

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v1.0.0
     - uses: dcodeIO/setup-node-nvm@master
       with:
-        node-version: 16
+        node-version: 20
     - name: Build
       run: |
         npm ci --no-audit


### PR DESCRIPTION
Node v18 is required for AssemblyScript#208.