### PR TITLE
Add Web Application Frameworks section

### DIFF
--- a/src/built-with-assemblyscript.md
+++ b/src/built-with-assemblyscript.md
@@ -115,6 +115,11 @@ A place for all things AssemblyScript. Feel free to add your projects and applic
 * [GLAS](https://github.com/lume/glas)<br />
   Web**GL** in **A**ssembly**S**cript, port of [Three.js](https://github.com/mrdoob/three.js/) to AssemblyScript.
 
+## Web Application Frameworks
+
+* [fui-as](https://github.com/zion-sati/fui-as)<br />
+  Build a11y-compliant WPF/SwiftUI-grade web apps in AssemblyScript running on the browser with Skia/Harfbuzz/ICU.
+
 ## Data Serialization / Deserialization
 
 * [karmem](https://github.com/inkeliz/karmem)<br />


### PR DESCRIPTION
Added a section for Web Application Frameworks with fui-as.

@JairusSW Let me know if you want me to put it under an existing section - just couldn't work out which one is the best for fui-as which is a Web App framework. 🙏 